### PR TITLE
feat(hotreloading): reload remote schema updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "apollo-link": "^0.7.0",
     "graphql-tools": "^2.2.1",
     "lodash": "^4.17.4",
-    "lodash.difference": "^4.5.0",
     "moleculer": "^0.11.1",
     "selectn": "^1.1.2"
   },

--- a/src/Gateway/GraphQLGateway.js
+++ b/src/Gateway/GraphQLGateway.js
@@ -1,6 +1,6 @@
 /**
  * @file createGraphQLGateway
- * @author Brad Decker <brad.decker@conciergeauctions.com>
+ * @author Brad Decker <brad@merlinlabs.com>
  *
  * The primary purpose of this file is to build a schema that stitches
  * together the schemas of all remote services that have been defined
@@ -9,138 +9,211 @@
  */
 import { mergeSchemas } from 'graphql-tools';
 import { printSchema, parse, graphql as execute } from 'graphql';
-import difference from 'lodash.difference';
+import { isEqual, difference } from 'lodash';
 import selectn from 'selectn';
 import fs from 'fs';
+import { promisify } from 'util';
 import { createRemoteSchema } from './createRemoteSchema';
 import { buildRelationalResolvers } from './buildRelationalResolvers';
 import { getRelatedTypes } from './utilities';
 
-import type { GraphQLSchema, DocumentNode } from 'graphql';
+import type { GraphQLSchema, DocumentNode, GraphQLType } from 'graphql';
 import type { ServiceBroker, ServiceWorker } from 'moleculer';
-import type { TypeRelationDefinitions } from '../Types/ServiceConfiguration';
+import type { RelationDefinitions } from '../Types/ServiceConfiguration';
 
-opaque type ServiceName = string;
+const waitFor = promisify(setTimeout);
 
+opaque type GraphQLServiceName = string;
+opaque type GraphQLTypeName = string;
+opaque type GraphQLRawSchema = string;
+opaque type FilePath = string;
+
+/**
+ * RemoteSchemaDefinition
+ *
+ * This type defines the format of data expected from
+ * graphql services when they broadcast graphqlService.connected
+ * or graphqlService.disconnected
+ */
+type RemoteSchemaDefinition = {
+  // The raw string schema set in the service
+  schema: GraphQLRawSchema,
+  // The remoteExecutableSchema created after discovery
+  remoteExecutableSchema?: GraphQLSchema,
+  // The raw string schema defining relationships in the service
+  relationships: GraphQLRawSchema,
+  // An object defining how to handle relationships set in the service
+  relationDefinitions: RelationDefinitions,
+  // The service name
+  serviceName: GraphQLServiceName,
+};
+
+/**
+ * GatewayOptions
+ *
+ * This type defines the format of options passed in the second
+ * parameter to the GraphQLGateway constructor
+ */
 type GatewayOptions = {
-  broker: ServiceBroker,
-  expectedTypes?: Array<string>,
-  waitTimeout?: number,
-  waitInterval?: number,
-  blacklist?: Array<string>,
+  // An array of services the user has requested to be ignored
+  blacklist?: Array<GraphQLServiceName>,
+  // An array of services the user has marked as required before start
+  expectedServices?: Array<GraphQLServiceName>,
+  // Boolean provided by user. If true, save a schema snapshot.
   generateSnapshot?: boolean,
-  snapshotPath?: string,
+  // Method provided by user that will be called when service is discovered.
+  onSchemaDiscovery?: (RemoteSchemaDefinition) => void,
+  // User provided file path to location for snapshot saving
+  snapshotPath?: FilePath,
+  // maximum length of time in milliseconds to wait for services
+  waitTimeout?: number,
+  // length of time in milliseconds to wait in between polling.
+  waitInterval?: number,
 };
 
-type RemoteSchemaMap = {
-  [TypeName: string]: GraphQLSchema,
+/**
+ * GatewaySettings
+ *
+ * This type defines the shape of the settings instance property on
+ * GraphQLGateway. It is computed from GatewayOptions.
+ */
+type GatewaySettings = {
+  // An array of service names to ignore when they connect
+  blacklist: Array<GraphQLServiceName>,
+  // An array of service names that are required before starting the gateway
+  expectedServices: Array<GraphQLServiceName>,
+  // Boolean to determine if a snapshot of the schema should be persisted to file
+  generateSnapshot: boolean,
+  // Method to call when a schema is discovered by the gateway
+  onSchemaDiscovery?: (RemoteSchemaDefinition) => void,
+  // Path to save the snapshot to
+  snapshotPath: FilePath,
+  // maximum length of time in milliseconds to wait for services to connect
+  waitTimeout: number,
+  // length of time in milliseconds to wait in between polling
+  waitInterval: number,
+}
+
+/**
+ * ConnectedServices
+ *
+ * This type defines a Map shape for the instance property on
+ * GraphQLGateway. The shape is an object with keys that are
+ * service's names, and values that are RemoteSchemaDefinitions.
+ * This map is used internally to store connected services for
+ * future use.
+ */
+type ConnectedServices = {
+  [service: GraphQLServiceName]: RemoteSchemaDefinition,
 };
 
-type RelationshipSchemas = {
-  [TypeName: string]: string,
-};
+/**
+ * concatDifference
+ *
+ * Compute the items from target that are not in source and then add them to
+ * the source.
+ */
+function concatDifference(source: Array<any>, target: Array<any>): Array<any> {
+  const diff = difference(target, source);
+  return source.concat(diff);
+}
 
-type GraphQLTypeServiceMap = {
-  [type: GraphQLTypeName]: ServiceName
-};
+/**
+ * computeTimeDiff
+ *
+ * Computers the number of milliseconds that have passed since start
+ */
+function computeTimeDiff(start: [number, number]): number {
+  const elapsed = process.hrtime(start);
+  const milliseconds = (elapsed[0] * 1000000) + (elapsed[1] / 1000000);
+  return Number(milliseconds.toFixed(0));
+}
 
 export class GraphQLGateway {
-  // Services to ignore
-  blacklist: Array<string> = ['$node'];
+  settings: GatewaySettings = {
+    // Services to ignore
+    blacklist: ['$node'],
+    expectedServices: [],
+    generateSnapshot: false,
+    snapshotPath: `${process.cwd()}/schema.snapshot.graphql`,
+    waitTimeout: 5000,
+    waitInterval: 100,
+  };
+
   // Passed in service broker used to make calls
   broker: ServiceBroker;
-  // Running list of discovered types and the service that they belong to
-  discoveredTypes: GraphQLTypeServiceMap = {};
-  // Define absolutely necessary types before schema can be complete
-  expectedTypes: Array<string> = [];
-  // If true, save a snapshot schema file everytime the schema changes
-  generateSnapshot: boolean = false;
-  // Boolean to track whether the schema has been initialized
-  initialized: boolean = false;
-  // Method to hook into service discovery.
-  onServiceDiscovery: (service: ServiceWorker) => void;
-  // All relationship resolver definitions in the remote schemas
-  relationDefinitions: TypeRelationDefinitions = {};
-  // Additional Schemas for relating objects across services
-  relationships: RelationshipSchemas = {};
-  // Remove Schema map for storing the remote schemas created
-  remoteSchemas: RemoteSchemaMap = {};
+
+  // An array of types that are required across services
+  requiredGraphQLTypes: Array<GraphQLTypeName> = [];
+
+  // An array of types that have already been discovered
+  discoveredGraphQLTypes: Array<GraphQLTypeName> = [];
+
+  // An object used to store connected service data
+  connectedServices: ConnectedServices = {};
+
   // The current schema for the gateway, computed by stitching remote schemas
   schema: ?GraphQLSchema = null;
+
   // Internal service for listening for events
   service: ?ServiceWorker = null;
-  // Path to save the snapshot to
-  snapshotPath: string = `${process.cwd()}/schema.snapshot.graphql`;
-  // Length of time in milliseconds to wait for expectedTypes
-  waitTimeout: number = 5000;
-  // Interval in milliseconds to poll for expectedTypes
-  waitInterval: number = 100;
 
-  handleServiceUpdate = async(opts): Promise<void> => {
-    const services = this.broker.services
-      .filter(service => service.settings.hasGraphQLSchema)
-      .filter(service => !this.blacklist.includes(service.name))
-      .filter(service => !this.discoveredTypes[service.settings.typeName]);
-
-    if (services.length > 0) {
-      for (const service of services) {
-        this.discoveredTypes[service.settings.typeName] = service.name;
-        await this.buildRemoteSchema(service);
-        if (this.onServiceDiscovery) {
-          this.onServiceDiscovery(service);
-        }
+  /**
+   * handleServiceConnected
+   *
+   * When a graphql service connects build a remote schema if the service is new
+   * or has updated definitions from the currently connected remote schema. If the
+   * remote schema is added or updated, rebuild the local gateway schema as well.
+   */
+  handleServiceConnected = async (
+    remoteSchemaDef: RemoteSchemaDefinition,
+  ): Promise<void> => {
+    const {
+      schema,
+      serviceName,
+      relationships,
+      relationDefinitions
+    } = remoteSchemaDef;
+    let changed = false;
+    if (this.connectedServices[serviceName]) {
+      const currentDefinition = this.connectedServices[serviceName];
+      if (schema !== currentDefinition.schema) changed = true;
+      if (!changed && relationships !== currentDefinition.relationships) changed = true;
+      if (!changed && !isEqual(relationDefinitions, currentDefinition.relationDefinitions)) {
+        changed = true;
       }
-      this.generateSchema();
+      if (!changed) return;
     }
+    if (this.settings.onSchemaDiscovery) {
+      this.settings.onSchemaDiscovery(remoteSchemaDef);
+    }
+    this.connectedServices[serviceName] = remoteSchemaDef;
+    await this.buildRemoteSchema(remoteSchemaDef);
+    this.rebuildSchema();
   };
 
-  // When nodes connect we scan their services for schemas and add stitch them in
-  handleNodeConnection = async ({ node }: Object): Promise<void> => {
-    const services = node.services.filter(
-      service => !this.discoveredTypes[service.settings.typeName]
-        && !this.blacklist.includes(service.name)
-        && service.settings.hasGraphQLSchema
-    );
-    if (services.length > 0) {
-      for (const service of services) {
-        this.discoveredTypes[service.settings.typeName] = service.name;
-        await this.buildRemoteSchema(service);
-        if (this.onServiceDiscovery) {
-          this.onServiceDiscovery(service);
-        }
-      }
-      this.generateSchema();
-    }
+  /**
+   * handleServiceDisconnected
+   *
+   * When a service reports disconnect, remove it from our connected services
+   * and rebuild the local stitched schema.
+   */
+  handleServiceDisconnected = async (remoteSchemaDef: RemoteSchemaDefinition): Promise<void> => {
+    this.removeExecutableSchema(remoteSchemaDef);
   };
 
-  // When nodes disconnect we scan their services for schemas and remove them
-  handleNodeDisconnected = async ({ node }: Object): Promise<void> => {
-    const services = node.services.filter(
-      service => this.remoteSchemas[service.settings.typeName]
-    );
-    if (services.length > 0) {
-      for (const service of services) {
-        await this.buildRemoteSchema(service);
-      }
-      this.generateSchema();
+  constructor(broker: ServiceBroker, options: GatewayOptions) {
+    this.broker = broker;
+    this.settings = {
+      ...this.settings,
+      ...options
     }
-  };
 
-  constructor(opts: GatewayOptions) {
-    this.broker = opts.broker;
-    if (opts.expectedTypes) this.expectedTypes = opts.expectedTypes;
-    if (opts.waitInterval) this.waitInterval = opts.waitInterval;
-    if (opts.waitTimeout) this.waitTimeout = opts.waitTimeout;
-    if (opts.blacklist) this.blacklist.concat(opts.blacklist);
-    if (opts.generateSnapshot) this.generateSnapshot = opts.generateSnapshot;
-    if (opts.snapshotPath) this.snapshotPath = opts.snapshotPath;
-    if (opts.onServiceDiscovery) this.onServiceDiscovery = opts.onServiceDiscovery;
     this.service = this.broker.createService({
       name: 'gateway',
       events: {
-        '$services.changed': this.handleServiceUpdate,
-        '$node.connected': this.handleNodeConnection,
-        '$node.disconnected': this.handleNodeDisconnected,
+        'graphqlService.connected': this.handleServiceConnected,
+        'graphqlService.disconnected': this.handleServiceDisconnected,
       },
       actions: {
         graphql: {
@@ -151,9 +224,23 @@ export class GraphQLGateway {
           handler: ctx => execute(this.schema, ctx.params.query, null, null, ctx.params.variables),
         },
       },
+      started: async () => {
+        const services = await this.broker.call('$node.services');
+        services
+          .filter(service => service.settings.hasGraphQLSchema)
+          .forEach(service => {
+            this.handleServiceConnected({ ...service.settings, serviceName: service.name }, true);
+          });
+      }
     });
   }
 
+  /**
+   * alphabetizeSchema
+   *
+   * In order to make sure snapshots are consistent we alphabetize types
+   * so that the order of types is reliable.
+   */
   alphabetizeSchema(schema: GraphQLSchema): GraphQLSchema {
     const queryType = schema._queryType;
     const fields = queryType.getFields();
@@ -170,68 +257,208 @@ export class GraphQLGateway {
     return schema;
   }
 
-  async buildRemoteSchema(service: ServiceWorker): Promise<void> {
-    const { settings: { typeName, relationships, relationDefinitions } } = service;
-    if (!this.remoteSchemas[typeName]) {
-      this.remoteSchemas[typeName] = await createRemoteSchema({
-        broker: this.broker,
-        service
-      });
-      if (relationships) {
-        this.relationships[typeName] = relationships;
-        this.relationDefinitions[typeName] = relationDefinitions;
-        const relatedTypes = getRelatedTypes(parse(relationships));
-        const missingTypes = difference(relatedTypes, this.discoveredTypes);
-        this.expectedTypes = this.expectedTypes.concat(missingTypes);
-      }
+  /**
+   * buildRemoteSchema
+   *
+   * Builds a remoteExecutableSchema for a service and computes required types
+   * that might span across multiple services. Also tracks already discovered types.
+   */
+  async buildRemoteSchema(remoteSchemaDef: RemoteSchemaDefinition): Promise<void> {
+    const { serviceName, relationships, schema, relationDefinitions } = remoteSchemaDef;
+    this.connectedServices[serviceName].remoteExecutableSchema = await createRemoteSchema({
+      broker: this.broker,
+      service: serviceName
+    });
+    const computedSchema = parse(schema);
+    const definedTypes = computedSchema
+      .definitions
+      .filter(d => {
+        if (d.kind === 'ObjectTypeDefinition') {
+          return !['Mutation', 'Query'].includes(d.name.value);
+        }
+        return false;
+      })
+      .map(d => selectn('name.value', d));
+
+    this.discoveredGraphQLTypes = concatDifference(this.discoveredGraphQLTypes, definedTypes);
+
+    if (relationships) {
+      const relatedTypes = getRelatedTypes(parse(relationships));
+      this.requiredGraphQLTypes = concatDifference(this.requiredGraphQLTypes, relatedTypes);
     }
   }
 
+  /**
+   * generateSchema
+   *
+   * Builds a single local schema using graphql-tools 'mergeSchemas' tool.
+   * Merges together all remote schemas and relationship definitions that
+   * span across services.
+   */
   generateSchema(): GraphQLSchema {
-    const schemas = Object.values(this.remoteSchemas).concat(Object.values(this.relationships));
-    const resolvers = buildRelationalResolvers(this.relationDefinitions);
+    const remoteSchemas = [];
+    const relationshipSchemas = [];
+    const relationDefinitions = {};
+    this.getConnectedServiceNames().forEach(serviceName => {
+      const remoteSchemaDef = this.connectedServices[serviceName];
+      if (remoteSchemaDef.remoteExecutableSchema) {
+        remoteSchemas.push(remoteSchemaDef.remoteExecutableSchema);
+      }
+      if (remoteSchemaDef.relationships) {
+        relationshipSchemas.push(remoteSchemaDef.relationships);
+      }
+      if (remoteSchemaDef.relationDefinitions) {
+        relationDefinitions[serviceName] = remoteSchemaDef.relationDefinitions;
+      }
+    });
+
+    const schemas = remoteSchemas.concat(relationshipSchemas);
+    const resolvers = buildRelationalResolvers(relationDefinitions);
     this.schema = mergeSchemas({
       schemas,
       resolvers,
     });
+
     this.schema = this.alphabetizeSchema(this.schema);
     if (this.generateSnapshot) this.recordSnapshot();
     return this.schema;
   }
 
-  recordSnapshot(): void {
+  /**
+   * getConnectedServiceNames
+   *
+   * Returns an array of service names currently connected to the gateway that
+   * also have a fully formed remoteExecutableSchema defined.
+   */
+  getConnectedServiceNames(): Array<GraphQLServiceName> {
+    return Object.keys(this.connectedServices)
+      .filter(serviceName => this.connectedServices[serviceName].remoteExecutableSchema);
+  }
+
+  /**
+   * rebuildSchema
+   *
+   * Rebuilds the schema if the schema already existed and no required types are missing
+   */
+  rebuildSchema(): void {
     if (this.schema) {
-      fs.writeFileSync(this.snapshotPath, printSchema(this.schema));
+      const required = difference(this.requiredGraphQLTypes, this.discoveredGraphQLTypes);
+      if (required.length > 0) {
+        if (this.broker.logger) {
+          this.broker
+            .logger
+            .warn(`Schema refresh found ${required.join(', ')} types yet to be discovered`);
+        }
+        return;
+      }
+      this.generateSchema();
     }
   }
 
   /**
-   * Wait for services expected
+   * recordSnapshot
+   *
+   * Persists a pretty printed schema to file if schema exists
    */
-  start(): Promise<GraphQLSchema> {
-    return new Promise((resolve, reject) => {
-      const maxTries = this.waitTimeout / this.waitInterval;
-      let tries = 0;
-      this.timer = setInterval(() => {
-        tries++;
-        if (tries >= maxTries) {
-          reject(new Error('Timeout'));
+  recordSnapshot(): void {
+    if (this.schema) {
+      fs.writeFileSync(this.settings.snapshotPath, printSchema(this.schema));
+    }
+  }
+
+  /**
+   * removeExecutableSchema
+   *
+   * When a service goes offline we remove the schema. This is not the long term
+   * approach. Ideally long term we will stub the resolvers on said type to return
+   * some sort of null response so that it doesn't cause outages on the client side
+   */
+  removeExecutableSchema(remoteSchemaDef: RemoteSchemaDefinition) {
+    const { serviceName, relationships, schema, relationDefinitions } = remoteSchemaDef;
+    const computedSchema = parse(schema);
+    const definedTypes = computedSchema
+      .definitions
+      .filter(d => {
+        if (d.kind === 'ObjectTypeDefinition') {
+          return !['Mutation', 'Query'].includes(d.name.value);
         }
-        const discoveredTypes = Object.keys(this.discoveredTypes);
-        const undiscovered = difference(this.expectedTypes, discoveredTypes);
-        if (discoveredTypes.length === 0) return;
-        if (discoveredTypes.some(type => !this.remoteSchemas[type])) return;
-        if (undiscovered.length > 0) {
-          if (this.broker.logger) {
-            const msg = `Still waiting for ${undiscovered.join(', ')} types to be discovered`;
-            this.broker.logger.warn(msg);
+        return false;
+      })
+      .map(d => selectn('name.value', d));
+
+    // remove the types defined in this schema from the discovered types
+    this.discoveredGraphQLTypes = difference(this.discoveredGraphQLTypes, definedTypes);
+    delete this.connectedServices[serviceName];
+    this.rebuildSchema();
+  }
+
+  /**
+   * start
+   *
+   * Starts the connected broker if required, then waits for required types
+   * and expected services to be discovered. It will also wait until at least
+   * one service is discovered.
+   *
+   * Calculates total time spent in each iteration and passes it recursively
+   * so that the waitTimeout setting can be respected.
+   */
+  async start(totalTime: number = 0): Promise<GraphQLSchema> {
+    const startTime = process.hrtime();
+    if (totalTime > this.settings.waitTimeout) {
+      throw new Error('Timeout');
+    }
+
+    let shouldRetry = false;
+    if (!this.broker._started) await this.broker.start();
+
+    const connectedServices = this.getConnectedServiceNames();
+    if (connectedServices.length === 0) {
+      shouldRetry = true;
+    }
+
+    if (!shouldRetry) {
+      const required = difference(this.requiredGraphQLTypes, this.discoveredGraphQLTypes);
+      const expected = difference(this.settings.expectedServices, connectedServices);
+      if (required.length > 0 || expected.length > 0) {
+        shouldRetry = true;
+        if (this.broker.logger) {
+          if (required.length > 0) {
+            this.broker
+              .logger
+              .warn(`Still waiting for ${required.join(', ')} types to be discovered`);
           }
-          return;
+          if (expected.length > 0) {
+            this.broker
+              .logger
+              .warn(`Still waiting for ${expected.join(', ')} services to be discovered`);
+          }
         }
-        clearInterval(this.timer);
-        this.generateSchema();
-        resolve(this.schema);
-      }, this.waitInterval);
-    });
+      }
+    }
+
+    if (shouldRetry) {
+      await waitFor(this.settings.waitInterval);
+      return await this.start(totalTime + computeTimeDiff(startTime));
+    }
+    if (this.broker.logger) {
+      this.broker
+        .logger
+        .info(`Initial schema generation took ${totalTime + computeTimeDiff(startTime)}ms`);
+    }
+    const schema = this.generateSchema();
+    return schema;
+  }
+
+  /**
+   * stop
+   *
+   * Resets internal stores of connected services and data
+   * then stops the broker.
+   */
+  stop() {
+    this.connectedServices = {};
+    this.requiredGraphQLTypes = [];
+    this.discoveredGraphQLTypes = [];
+    return this.broker.stop();
   }
 }

--- a/src/Gateway/createRemoteSchema.js
+++ b/src/Gateway/createRemoteSchema.js
@@ -8,11 +8,11 @@ import { MoleculerLink } from './MoleculerLink';
 
 type RemoteSchemaOptions = {
   broker: ServiceBroker,
-  service: Service
+  service: string,
 }
 
 export async function createRemoteSchema({ broker, service }: RemoteSchemaOptions) {
-  const link = new MoleculerLink({ broker, service: service.name });
+  const link = new MoleculerLink({ broker, service: service });
   const schema = await introspectSchema(link);
   return makeRemoteExecutableSchema({ schema, link });
 }

--- a/src/createGraphqlMixin.js
+++ b/src/createGraphqlMixin.js
@@ -8,14 +8,12 @@ import {
 import { graphql as execute } from 'graphql';
 
 export const createGraphqlMixin = ({
-  typeName,
   schema,
   resolvers,
   relationships,
   relationDefinitions
 }) => ({
   settings: {
-    typeName,
     schema,
     relationships,
     relationDefinitions,
@@ -28,23 +26,34 @@ export const createGraphqlMixin = ({
         variables: { type: 'object', optional: true },
       },
       handler(ctx) {
-        return execute(this.schema, ctx.params.query, this.resolvers, ctx, ctx.params.variables);
+        return execute(
+          this.graphqlSchema,
+          ctx.params.query,
+          this.resolvers,
+          ctx,
+          ctx.params.variables
+        );
       },
     },
   },
   created() {
     this.resolvers = resolvers;
-    this.schema = makeExecutableSchema({ typeDefs: [schema], resolvers });
+    this.graphqlSchema = makeExecutableSchema({ typeDefs: [schema], resolvers });
   },
   started() {
     this.broker.broadcast('graphqlService.connected', {
-      typeName,
       schema,
+      serviceName: this.name,
       relationships,
       relationDefinitions,
     });
   },
   stopped() {
-    this.broker.broadcast('graphqlService.disconnected', { typeName });
+    this.broker.broadcast('graphqlService.disconnected', {
+      schema,
+      serviceName: this.name,
+      relationships,
+      relationDefinitions,
+    });
   },
 });

--- a/tests/queryResolution.spec.js
+++ b/tests/queryResolution.spec.js
@@ -170,14 +170,12 @@ const runSuites = (suiteName, buildQueryResolver) => {
 
         ref.broker.start();
 
-        ref.gateway = new GraphQLGateway({
-          broker: ref.broker,
-        });
+        ref.gateway = new GraphQLGateway(ref.broker);
 
         return ref.gateway.start();
       });
 
-      afterAll(() => ref.broker.stop());
+      afterAll(() => ref.gateway.stop());
 
       runTests(buildQueryResolver({ ref, clientKey: 'broker' }));
     });
@@ -196,26 +194,31 @@ const runSuites = (suiteName, buildQueryResolver) => {
       beforeAll(() => {
         ref.client = new ServiceBroker({
           nodeID: 'client',
+          namespace: 'queryResolution',
           transporter: new Transporters.MQTT('mqtt://localhost:1883')
         });
 
         ref.broker = new ServiceBroker({
           nodeID: 'gatewayMultiple',
+          namespace: 'queryResolution',
           transporter: new Transporters.MQTT('mqtt://localhost:1883')
         });
 
         ref.authorBroker = new ServiceBroker({
           nodeID: 'author',
+          namespace: 'queryResolution',
           transporter: new Transporters.MQTT('mqtt://localhost:1883')
         });
 
         ref.bookBroker = new ServiceBroker({
           nodeID: 'book',
+          namespace: 'queryResolution',
           transporter: new Transporters.MQTT('mqtt://localhost:1883')
         });
 
         ref.chapterBroker = new ServiceBroker({
           nodeID: 'chapter',
+          namespace: 'queryResolution',
           transporter: new Transporters.MQTT('mqtt://localhost:1883')
         });
 
@@ -223,16 +226,13 @@ const runSuites = (suiteName, buildQueryResolver) => {
         ref.bookBroker.createService(bookSvc);
         ref.chapterBroker.createService(chapterSvc);
 
-        ref.gateway = new GraphQLGateway({
-          broker: ref.broker,
-        });
+        ref.gateway = new GraphQLGateway(ref.broker);
 
         return Promise.all([
           ref.client.start(),
           ref.authorBroker.start(),
           ref.bookBroker.start(),
           ref.chapterBroker.start(),
-          ref.broker.start(),
           ref.gateway.start(),
         ])
       });
@@ -242,7 +242,7 @@ const runSuites = (suiteName, buildQueryResolver) => {
         ref.authorBroker.stop(),
         ref.bookBroker.stop(),
         ref.chapterBroker.stop(),
-        ref.broker.stop(),
+        ref.gateway.stop(),
       ]))
 
       runTests(buildQueryResolver({ ref, clientKey: 'client' }));

--- a/tests/types/Author.js
+++ b/tests/types/Author.js
@@ -1,7 +1,7 @@
 import { createGraphqlMixin } from '../../src/createGraphqlMixin';
 import { authors } from './data';
 
-const schema = `
+export const schema = `
   type Author {
     id: Int,
     name: String,
@@ -67,7 +67,6 @@ const resolvers = {
 };
 
 const authorGraphQL = createGraphqlMixin({
-  typeName: 'Author',
   schema,
   resolvers,
   relationships,

--- a/tests/types/Book.js
+++ b/tests/types/Book.js
@@ -14,6 +14,21 @@ const schema = `
     books: [Book],
     booksByAuthor(authorId: Int!): [Book],
   }
+
+  input UpdateBookInput {
+    id: Int!
+    clientMutationId: Int!
+    title: String
+  }
+
+  type UpdateBookPayload {
+    book: Book
+    clientMutationId: Int
+  }
+
+  type Mutation {
+    updateBook(input: UpdateBookInput!): UpdateBookPayload,
+  }
 `;
 
 const relationships = `
@@ -40,18 +55,29 @@ const relationDefinitions = {
   },
 };
 
-const queries = {
+const Query = {
   books: () => books,
   book: (_, { id }) => books.find(book => book.id === id),
   booksByAuthor: (_, { authorId }) => books.filter(book => book.authorId === authorId),
 };
 
+const Mutation = {
+  updateBook(_, { id, title, clientMutationId }) {
+    const bookIdx = books.findIndex(book => book.id === id);
+    const book = books[authorIdx];
+    if (!title) return book;
+    book.title = title;
+    books[authorIdx] = book;
+    return { book, clientMutationId };
+  }
+}
+
 const resolvers = {
-  Query: queries,
+  Query,
+  Mutation,
 };
 
 const bookGraphQL = createGraphqlMixin({
-  typeName: 'Book',
   schema,
   resolvers,
   relationships,

--- a/tests/types/Chapter.js
+++ b/tests/types/Chapter.js
@@ -42,7 +42,6 @@ const resolvers = {
 };
 
 const chapterGraphQL = createGraphqlMixin({
-  typeName: 'Chapter',
   schema,
   resolvers,
   relationships,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,10 +2425,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-
 lodash@4.17.4, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
Breaking Changes:
1. the broker arg has been moved to be the first and only required
argument.
2. Settings argument has been move to the second position and remains an
object.
3. expectedTypes setting has been renamed "expectedServices"
4. Probably more. WIll update as i remember them.

This completely refactors the Gateway and how it was handling discovery
of services. The new way is much more lean and will scale better as it
will only care about services created with the accompanied mixin.