### PR TITLE
Add graphqlContext to object passed to service call

### DIFF
--- a/src/Gateway/MoleculerLink.js
+++ b/src/Gateway/MoleculerLink.js
@@ -14,7 +14,7 @@ function createMoleculerLink(opts: ServiceOptions): ApolloLink {
   return new ApolloLink(
     operation =>
       new Observable(observer => {
-        const { credentials, fetcherOptions } = operation.getContext();
+        const { credentials, fetcherOptions, graphqlContext } = operation.getContext();
         const { operationName, extensions, variables, query } = operation;
         const { broker, service } = opts;
 
@@ -23,7 +23,8 @@ function createMoleculerLink(opts: ServiceOptions): ApolloLink {
           query: print(query),
           variables,
           extensions,
-          operationName
+          operationName,
+          graphqlContext
         })
           .then(result => {
             observer.next(result);

--- a/tests/queryResolution.spec.js
+++ b/tests/queryResolution.spec.js
@@ -17,7 +17,7 @@ import bookSvc from './types/Book';
 import chapterSvc from './types/chapter';
 import * as dataSource from './types/data';
 
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 
 /**
  * @param {function} resolveQuery

--- a/tests/queryResolution.spec.js
+++ b/tests/queryResolution.spec.js
@@ -17,7 +17,7 @@ import bookSvc from './types/Book';
 import chapterSvc from './types/chapter';
 import * as dataSource from './types/data';
 
-jest.setTimeout(20000);
+jest.setTimeout(10000);
 
 /**
  * @param {function} resolveQuery


### PR DESCRIPTION
This will allow the GraphQL context to be available to the services. 

Here is an example use case which will pass user information from a request handled by graphqlHTTP to a service.

```  
app.use('/graphql', graphqlHTTP((request, response) => ({
    schema: gateway.schema,
    context: { user: request.user },
})));
```

Then in a service:
```
const GraphQLMixin = createGraphqlMixin({
    typeName: 'Example',
    schema,
    resolvers: {
        Query: {
            async example(_, {}, context, info) {
                console.log(context.params.graphqlContext.user); // this is now available
            },
        },
    },
});
```


